### PR TITLE
chore: upgrade checkout action to v4

### DIFF
--- a/.github/workflows/gh-pages-cleanup.yml
+++ b/.github/workflows/gh-pages-cleanup.yml
@@ -6,7 +6,7 @@ env:
 
 on:
   schedule:
-    - cron: "0 9 * * 1"
+    - cron: '0 9 * * 1'
 
 jobs:
   cleanup:
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'release:')"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'release:')"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node and yarn
         uses: './.github/actions/yarn-node-install'
@@ -66,7 +66,7 @@ jobs:
     needs: lint
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node and yarn
         uses: './.github/actions/yarn-node-install'
@@ -89,7 +89,7 @@ jobs:
       BLACKDUCK_TOKEN: ${{ secrets.BLACKDUCK_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node and yarn
         uses: './.github/actions/yarn-node-install'
@@ -167,7 +167,7 @@ jobs:
     needs: blackduck-scan
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node and yarn
         uses: './.github/actions/yarn-node-install'
@@ -185,7 +185,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'release:')
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       matrix: ${{ steps.filter-unpublished-packages.outputs.result }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           fetch-depth: 2


### PR DESCRIPTION


## Description

checkout action v3 uses node16 which is deprecated by GitHub.
Upgrading to v4 can provide performance improvements
## Issue

NA

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [x] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [x] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [x] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->