### PR TITLE
DTUI-87: Fix automated Versioning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,12 +184,19 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'release:')
     steps:
+      - name: Generate CI_BOT Token
+        id: ci-bot-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CI_BOT_ID }}
+          private-key: ${{ secrets.CI_BOT_PRIVATE_KEY }}
+
       - name: Checkout branch
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.ci-bot-token.outputs.token }}
 
       - name: Setup node and yarn
         uses: './.github/actions/yarn-node-install'


### PR DESCRIPTION
## Description

<!-- Provide a detailed description about the nature of your PR and what it solves -->

Migrating from GHE to Public Github introduced a new security measure, and we can not directly push to a protected branch from Github Actions. This Fixes pushing to main branch with custom protection rules, from the CI Workflow. 
Changes:
* New GitHub App (`dt-dds-ci-bot`) with Read and Write permissions for this repository 
* Allow `dt-dds-ci-bot` to bypass main branch rules for direct pushes 
* Call create-github-app-token action to get CI Bot (GH App) token
* Feed the token to checkout action to run git commands as CI_BOT

## Issue

<!-- If this pull request is related to an existing issue, reference it here using the issue number (e.g., "Fixes #123"). If not, explain the reason for the changes. -->
[DTUI-87](https://jir.t3.daimlertruck.com/browse/DTUI-87)

## Screenshots

<!-- Please provide screenshots, if any visual changes are present -->

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Tests
- [ ] Other (please specify):

## Check requirements

- [ ] The code follows the project's coding standards and guidelines
- [ ] Documentation is updated accordingly
- [ ] All existing tests are passing
- [ ] I have added new tests to cover the changes

## Live Preview

<!-- Url will be added by the pipeline, after deploy is completed -->